### PR TITLE
Fixes ReRAM Verilog-A model naming convention.

### DIFF
--- a/cells/reram_cell/sky130_fd_pr_reram__reram_cell.va
+++ b/cells/reram_cell/sky130_fd_pr_reram__reram_cell.va
@@ -17,7 +17,7 @@
 `include "constants.vams"
 `include "disciplines.vams"
 
-module rram2(TE, BE);
+module sky130_fd_pr_reram__reram_cell(TE, BE);
     inout TE; // top electrode
     inout BE; // bottom electrode
     electrical TE, BE;


### PR DESCRIPTION
Fixes: #19 

Signed-off-by: Ethan Mahintorabi <ethanmoon@google.com>